### PR TITLE
fix: broken spec. for `base32_clockwork:encode/1`

### DIFF
--- a/src/base32_clockwork.erl
+++ b/src/base32_clockwork.erl
@@ -4,7 +4,7 @@
 
 -import(base32_utils, [rev_bits_list_to_binary/1, bits_list_size/1]).
 
--spec encode(binary()) -> binary().
+-spec encode(iolist()) -> binary().
 encode(Data) ->
     encode0(Data, []).
 


### PR DESCRIPTION
## Motivation

Used by [`kivra_core`](https://github.com/kivra/kivra_core/blob/9b9cdd9cca458374047c2de20ac7cac1e13a9785/src/schema/kivramailschema.erl#L181).